### PR TITLE
Update amazonlinux tag to a compatible version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:latest
+FROM public.ecr.aws/amazonlinux/amazonlinux:2018.03
 
 RUN amazon-linux-extras install docker
 


### PR DESCRIPTION
Currently the `latest` tag for the amazonlinux causes this error

```
 Status: Downloaded newer image for public.ecr.aws/amazonlinux/amazonlinux:latest
   ---> 08e277251399
  Step 2/6 : RUN amazon-linux-extras install docker
   ---> Running in e573e265f255
  /bin/sh: line 1: amazon-linux-extras: command not found
  The command '/bin/sh -c amazon-linux-extras install docker' returned a non-zero code: 127
```